### PR TITLE
Fix root_cap = None

### DIFF
--- a/shinysdr/config.py
+++ b/shinysdr/config.py
@@ -103,7 +103,8 @@ class Config(object):
         self._not_finished()
         # TODO: See if we're reinventing bits of Twisted service stuff here
         
-        root_cap = unicode(root_cap)
+        if root_cap is not None:
+            root_cap = unicode(root_cap)
         if len(root_cap) <= 0:
             raise ValueError('config.serve_web: root_cap must be None or a nonempty string')
         

--- a/shinysdr/config.py
+++ b/shinysdr/config.py
@@ -105,8 +105,8 @@ class Config(object):
         
         if root_cap is not None:
             root_cap = unicode(root_cap)
-        if len(root_cap) <= 0:
-            raise ValueError('config.serve_web: root_cap must be None or a nonempty string')
+            if len(root_cap) <= 0:
+                raise ValueError('config.serve_web: root_cap must be None or a nonempty string')
         
         def make_service(app, note_dirty):
             # TODO: This is, of course, not where session objects should be created. Working on it...


### PR DESCRIPTION
Previously it would try to convert it to unicode and set the root_cap to the string "None"