### PR TITLE
Implement PSK31 demodulator

### DIFF
--- a/shinysdr/test/plugins/test_psk31.py
+++ b/shinysdr/test/plugins/test_psk31.py
@@ -1,0 +1,31 @@
+# Copyright 2014, 2015, 2016, 2017 Kevin Reid <kpreid@switchb.org>
+#
+# This file is part of ShinySDR.
+# 
+# ShinySDR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# ShinySDR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with ShinySDR.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, unicode_literals
+
+from twisted.trial import unittest
+
+from zope.interface.verify import verifyObject
+
+from shinysdr.plugins.psk31 import PSK31Demodulator
+from shinysdr.interfaces import IDemodulator
+from shinysdr.test.testutil import DemodulatorTestCase
+
+
+class TestPSK31Demodulator(DemodulatorTestCase):
+    def setUp(self):
+        self.setUpFor(mode='PSK31')


### PR DESCRIPTION
Works, although with the current UI hard to use:

- It only decodes one thing at a time, so it's difficult to click on something to see what it is before it stops.
- Tuning accurately is difficult since the FFT resolution is low. gr-radioteletype has no AFC yet, though in the testing I've done so far it's very tolerant of frequency offset.
- It's difficult to visually confirm the signal is indeed PSK31 and not PSK63, etc, again due to FFT resolution.

(Incidentally, PSK63 would be easy to implement: just downsample by half as much.)

![2017-06-03-080732_1971x1446_scrot](https://cloud.githubusercontent.com/assets/1232472/26753436/fd87f386-4833-11e7-980f-0c94fb504b8a.png)
